### PR TITLE
Fix imports and rollup settings for standardized-audio-context

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,7 +40,7 @@ module.exports = [
         exclude: "node_modules/**"
       }),
       // NOTE: `main: false` allows npm link'ed packages to be resolved too.
-      resolve({ main: false, browser: true }),
+      resolve({ main: false, module: true, browser: true }),
       // NOTE: styled-components won't compile without this configuration of
       // commonjs: https://github.com/styled-components/styled-components/issues/1654#issuecomment-441151140
       commonjs({

--- a/src/js/SynthAdapter.js
+++ b/src/js/SynthAdapter.js
@@ -1,5 +1,5 @@
 // @format
-import AudioContext from "standardized-audio-context";
+import { AudioContext, AudioWorkletNode } from "standardized-audio-context";
 
 export default class SynthAdapter {
   constructor(path, moduleId, envelope) {


### PR DESCRIPTION
Hi Tim,

this pull request changes the imports from `standardized-audio-context`. Once `standardized-audio-context` is used it requires all objects and classes that are part of the Web Audio API to be imported from `standardized-audio-context`. This is required to avoid any conflicts with other scripts which may rely on the globally available Web Audio API with all its quirks.

I also updated the rollup config to resolve the `module` property before trying to resolve the `main` property. I could not test this locally though. I hope it helps.