### PR TITLE
Up-mixes mono output to stereo

### DIFF
--- a/src/js/SynthAdapter.js
+++ b/src/js/SynthAdapter.js
@@ -43,7 +43,7 @@ export default class SynthAdapter {
     if (!this.context) {
       this.context = new AudioContext();
       await this.context.audioWorklet.addModule(this.path);
-      this.worklet = new AudioWorkletNode(this.context, this.moduleId);
+      this.worklet = new AudioWorkletNode(this.context, this.moduleId, { outputChannelCount: [1] });
       this.worklet.connect(this.context.destination);
 
       // TODO: We assume 4 oscillators here, but actually we should define

--- a/src/js/worklets/synth.js
+++ b/src/js/worklets/synth.js
@@ -37,7 +37,7 @@ class SynthWorklet extends AudioWorkletProcessor {
   }
 
   process(inputs, outputs, parameters) {
-    // NOTE: We only use a single channel to generate our sounds.
+    // NOTE: We only use a single channel to generate our sounds, will be up-mixed to stereo.
     const outputChannel = outputs[0][0];
     const sample = this.voiceManager.nextSample(outputChannel.length);
     for (let i = 0; i < sample.size(); i++) {


### PR DESCRIPTION
Fixes #16. By default it seems like the `AudioWorkletNode` was set to use stereo-based output, and only the left (mono) channel was filled with any data. By explicitly setting the `outputChannelCount` of the node to 1 for the main output, the Web Audio API will automatically up-mix from the mono output of the node to the multi-channel output of the `destination`. 

You can compare the two versions by trying both https://timdaub.github.io/wasm-synth/ and https://joshwilsonvu.github.io/wasm-synth/.

You might notice that the forked version sounds louder; it is 3 decibels louder on stereo speakers/headphones by virtue of doubling the signal.

Nice synth, thanks for your work!